### PR TITLE
Expand Xcode variables in the environment variables where possible

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BPUtilsTests.m
+++ b/Bluepill-cli/BPInstanceTests/BPUtilsTests.m
@@ -59,4 +59,14 @@
                                          };
     XCTAssert([dictionary isEqualToDictionary:expectedDictionary], @"Dictionary doesn't match expectation");
 }
+
+- (void)testEnvironmentVariableExpansion {
+    NSString *schemePath = @"/Users/test/XcodeProject/XcodeProject.xcodeproj/xcshareddata/xcschemes/XcodeProjectTests.xcscheme";
+
+    XCTAssertEqualObjects([BPUtils expandEnvironmentVariable:@"$(SRCROOT)/Resources" withSchemePath:schemePath], @"/Users/test/XcodeProject/Resources");
+    XCTAssertEqualObjects([BPUtils expandEnvironmentVariable:@"$(SOURCE_ROOT)/Resources" withSchemePath:schemePath], @"/Users/test/XcodeProject/Resources");
+    XCTAssertEqualObjects([BPUtils expandEnvironmentVariable:@"$(PROJECT_DIR)/Resources" withSchemePath:schemePath], @"/Users/test/XcodeProject/Resources");
+    XCTAssertEqualObjects([BPUtils expandEnvironmentVariable:@"$(PROJECT_FILE_PATH)" withSchemePath:schemePath], @"/Users/test/XcodeProject/XcodeProject.xcodeproj");
+}
+
 @end

--- a/Source/Shared/BPUtils.h
+++ b/Source/Shared/BPUtils.h
@@ -103,6 +103,14 @@ typedef NS_ENUM(int, BPKind) {
 + (NSDictionary *)buildArgsAndEnvironmentWith:(NSString *)schemePath;
 
 /*!
+ * @discussion return the environment variable from a scheme, expanding Xcode variables where possible (such as SRCROOT)
+ * @param environmentVariable environment variable value
+ * @param schemePath the path to the scheme file
+ * @return the expanded environment variable value
+ */
++ (NSString *)expandEnvironmentVariable:(NSString *)environmentVariable withSchemePath:(NSString *)schemePath;
+
+/*!
  * @discussion run a shell command and return the output
  * @param command the shell command to run
  * @return return the shell output


### PR DESCRIPTION
For example $(SRCROOT) in an environment variable will be evaluated if the scheme specified is inside an xcodeproj package.